### PR TITLE
Make GitHub Action produce zip of data directly instead of zip containing mpackage

### DIFF
--- a/.github/workflows/muddler.yml
+++ b/.github/workflows/muddler.yml
@@ -24,9 +24,12 @@ jobs:
         run: |
           cd package
           ../muddler/muddle-shadow-0.5/bin/muddle
+          cd build
+          mv tmp tts-tim
+          cd ../..
 
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2
         with:
           name: tts-tim
-          path: package/build/tts-tim.mpackage
+          path: package/build/tts-tim/


### PR DESCRIPTION
Instead of exporting the mpackage file, which the GitHub action would then zip, I just will give it a folder to zip instead.  That way it can be opened up directly in Mudlet.

A zip file of the data is same as mpackage file with the data.